### PR TITLE
Fix: Prevent interactive timezone prompt in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 # Instalar dependencias del sistema: ffmpeg es crucial, git para instalar whisperx desde repo
 # La imagen pytorch/pytorch ya es ubuntu-based y tiene muchas cosas.
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     git \


### PR DESCRIPTION
Set DEBIAN_FRONTEND=noninteractive in the Dockerfile before running apt-get install. This prevents the build process from hanging due to interactive prompts, specifically the timezone configuration prompt that can occur during package installation.