### PR TITLE
Fix: Use explicit sample rate for diarization in app/main.py

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -302,7 +302,7 @@ async def transcribe_audio(
 <<<<<<< HEAD
                         audio_for_diarize = whisperx.load_audio(temp_audio_path) # Recargar o usar el ya cargado si aplica
                         diarize_segments = diarize_pipeline(
-                            {"waveform": torch.from_numpy(audio_for_diarize).unsqueeze(0), "sample_rate": whisperx.SAMPLE_RATE},
+                            {"waveform": torch.from_numpy(audio_for_diarize).unsqueeze(0), "sample_rate": 16000},
 =======
                         if loaded_audio_data is None:
                             # Este caso no debería ocurrir si la alineación (que carga el audio) es un prerrequisito.
@@ -311,7 +311,7 @@ async def transcribe_audio(
                         
                         logger.info("Usando datos de audio cargados previamente para diarización.")
                         diarize_segments = diarize_pipeline(
-                            {"waveform": torch.from_numpy(loaded_audio_data).unsqueeze(0), "sample_rate": whisperx.SAMPLE_RATE},
+                            {"waveform": torch.from_numpy(loaded_audio_data).unsqueeze(0), "sample_rate": 16000},
 >>>>>>> origin/general-adjustments
                             min_speakers=min_speakers,
                             max_speakers=max_speakers


### PR DESCRIPTION
Replaced `whisperx.SAMPLE_RATE` with the integer literal 16000 in the diarization pipeline call. The `whisperx.SAMPLE_RATE` constant is not exposed at the top-level `whisperx` module when imported as `import whisperx`.

The `whisperx.load_audio` function already ensures that audio data is resampled to 16000 Hz, which is the standard for Whisper models and expected by the pyannote.audio diarization pipeline. This change directly provides the correct sample rate, resolving the AttributeError.